### PR TITLE
Micro-simulator in C

### DIFF
--- a/crates/c/examples/circuit.c
+++ b/crates/c/examples/circuit.c
@@ -23,14 +23,13 @@ int main(int argc, char *argv[])
 
 	printf("%s\n", qibo_core_circuit_draw(c));
 	
-	// Initialize state vector
+	// Initialize 5-qubit state vector
     complex double state[32] = { 0 };
 	state[0] = 1;
 	
 	// Execute circuit
 	execute_circuit(c, state);
 
-	printf("\n");
 	// Print state vector
 	print_state(state, 32);
 	

--- a/crates/c/examples/circuit.c
+++ b/crates/c/examples/circuit.c
@@ -1,5 +1,16 @@
 #include <stdio.h>
+#include <complex.h>
 #include "qibo_core_c.h"
+#include "microsim.h"
+
+
+void print_state(complex double *state, const size_t size) {
+    //const size_t size = sizeof(state) / sizeof(state[0]);
+    for (size_t i=0; i < size; i++) {
+        printf("%ld: %.4f, %.4f\n", i, creal(state[i]), cimag(state[i]));
+    }
+}
+
 
 int main(int argc, char *argv[])
 {
@@ -11,5 +22,17 @@ int main(int argc, char *argv[])
 	qibo_core_circuit_add(c, "CNOT", (size_t[]) {0, 3}, 2);
 
 	printf("%s\n", qibo_core_circuit_draw(c));
+	
+	// Initialize state vector
+    complex double state[32] = { 0 };
+	state[0] = 1;
+	
+	// Execute circuit
+	execute_circuit(c, state);
+
+	printf("\n");
+	// Print state vector
+	print_state(state, 32);
+	
 	return 0;
 }

--- a/crates/c/examples/compile.sh
+++ b/crates/c/examples/compile.sh
@@ -1,4 +1,0 @@
-export PKG_CONFIG_PATH=/home/stavros/qiboteam/qibo-core/crates/c/prefix/lib/x86_64-linux-gnu/pkgconfig
-export LD_LIBRARY_PATH=/home/stavros/qiboteam/qibo-core/crates/c/prefix/lib/x86_64-linux-gnu
-
-cc circuit.c -o circuit -I/home/stavros/qiboteam/qibo-core/crates/c/prefix/include/qibo_core_c -L/home/stavros/qiboteam/qibo-core/crates/c/prefix/lib/x86_64-linux-gnu -lqibo_core_c

--- a/crates/c/examples/compile.sh
+++ b/crates/c/examples/compile.sh
@@ -1,0 +1,4 @@
+export PKG_CONFIG_PATH=/home/stavros/qiboteam/qibo-core/crates/c/prefix/lib/x86_64-linux-gnu/pkgconfig
+export LD_LIBRARY_PATH=/home/stavros/qiboteam/qibo-core/crates/c/prefix/lib/x86_64-linux-gnu
+
+cc circuit.c -o circuit -I/home/stavros/qiboteam/qibo-core/crates/c/prefix/include/qibo_core_c -L/home/stavros/qiboteam/qibo-core/crates/c/prefix/lib/x86_64-linux-gnu -lqibo_core_c

--- a/crates/c/microsimulator/microsim.c
+++ b/crates/c/microsimulator/microsim.c
@@ -1,0 +1,113 @@
+#include <stdio.h>
+#include <complex.h>
+#include <math.h>
+#include <string.h>
+#include <stdlib.h>
+#include "qibo_core_c.h"
+#include "microsim.h"
+
+
+typedef struct {
+    complex double h[4];
+    complex double x[4];
+    complex double y[4];
+    complex double z[4];
+} Matrices;
+
+
+Matrices create() {
+    double const h = 1.0 / sqrt(2);
+    Matrices const m = {
+        {h, h, h, -h},
+        {0, 1, 1, 0},
+        {0, -I, I, 0},
+        {1, 0, 0, -1}
+    };
+    return m;
+}
+
+int compare(const void *a, const void *b) {
+    return (*(int*)a - *(int*)b);
+}
+
+size_t control_index(size_t const g, size_t const *qubits, size_t const nqubits) {
+    size_t i = g;
+    for (size_t j = 0; j < nqubits; j++) {
+        size_t const n = qubits[j];
+        size_t const k = 1 << n;
+        i = ((i >> n) << (n + 1)) + (i & (k - 1)) + k;
+    }
+    return i;
+}
+
+void apply_controlled_gate(
+    complex double *state, 
+    complex double const *gate, 
+    size_t const *qubits,
+    size_t const ncontrols,
+    size_t const nqubits
+) {
+    size_t target = qubits[0];
+    
+    size_t sorted_qubits[ncontrols + 1];
+    memcpy(sorted_qubits, qubits, (ncontrols + 1) * sizeof(size_t));
+    for (size_t i = 0; i < ncontrols + 1; i++) {
+        sorted_qubits[i] = nqubits - sorted_qubits[i] - 1;
+    }
+    qsort(sorted_qubits, ncontrols + 1, sizeof(size_t), compare);
+
+    size_t const nstates = 1 << (nqubits - ncontrols - 1);
+    size_t const tk = 1 << (nqubits - target - 1);
+    // TODO: This can be parallelized for large number of qubits
+    for (size_t g = 0; g < nstates; g++) {
+        size_t const i2 = control_index(g, sorted_qubits, ncontrols + 1);
+        size_t const i1 = i2 - tk;
+        complex double const state1 = state[i1];
+        complex double const state2 = state[i2];
+        state[i1] = gate[0] * state1 + gate[1] * state2;
+        state[i2] = gate[2] * state1 + gate[3] * state2;
+    }
+}
+
+void execute_circuit(qibo_core_circuit *circuit, complex double *state) {
+	Matrices gates = create();
+
+	size_t const n_elements = qibo_core_circuit_n_elements(circuit);
+	size_t const n_gates = qibo_core_circuit_n_gates(circuit);
+
+	for (size_t gid = 0; gid < n_gates; gid++) {
+		char const *gate = qibo_core_circuit_gate(circuit, gid);
+		complex double *matrix;
+        // get matrix corresponding to the gate
+		if (strcmp(gate, "H") == 0) {
+			matrix = gates.h;
+		} else if (strcmp(gate, "Y") == 0) {
+			matrix = gates.y;
+		} else if (strcmp(gate, "Z") == 0) {
+			matrix = gates.z;
+		} else {
+			matrix = gates.x;
+		}
+		
+        // calculate number of control qubits
+        // maybe can be improved if we expose gate n_elements to C API
+        // but this will change anyway when we implement ``controlled_by``
+		size_t n_controls = 0;
+		if (strcmp(gate, "CNOT") == 0) {
+			n_controls = 1;
+		}
+
+		size_t const *elements;
+		size_t n_gate_elements;
+		qibo_core_circuit_elements(circuit, gid, &elements, &n_gate_elements);
+
+		apply_controlled_gate(state, matrix, elements, n_controls, n_elements);
+		
+		printf("\n%ld %ld %s ", n_gate_elements, n_controls, gate);
+		for (size_t i = 0; i < n_gate_elements; i++) {
+			printf("%ld ", elements[i]);
+		}
+		qibo_core_circuit_free_elements(elements, n_gate_elements);
+	}
+	printf("\n");
+}

--- a/crates/c/microsimulator/microsim.c
+++ b/crates/c/microsimulator/microsim.c
@@ -102,11 +102,7 @@ void execute_circuit(qibo_core_circuit *circuit, complex double *state) {
 		qibo_core_circuit_elements(circuit, gid, &elements, &n_gate_elements);
 
 		apply_controlled_gate(state, matrix, elements, n_controls, n_elements);
-		
-		printf("\n%ld %ld %s ", n_gate_elements, n_controls, gate);
-		for (size_t i = 0; i < n_gate_elements; i++) {
-			printf("%ld ", elements[i]);
-		}
+
 		qibo_core_circuit_free_elements(elements, n_gate_elements);
 	}
 	printf("\n");

--- a/crates/c/microsimulator/microsim.h
+++ b/crates/c/microsimulator/microsim.h
@@ -1,0 +1,8 @@
+#ifndef MICROSIM_H
+#define MICROSIM_H
+
+#include "qibo_core_c.h"
+
+void execute_circuit(qibo_core_circuit *circuit, complex double *state);
+
+#endif

--- a/crates/c/src/lib.rs
+++ b/crates/c/src/lib.rs
@@ -5,6 +5,7 @@ use std::slice;
 
 use qibo_core::prelude::*;
 
+
 #[no_mangle]
 pub extern "C" fn qibo_core_circuit_new(n_elements: usize) -> Box<Circuit> {
     Box::new(Circuit::new(n_elements))
@@ -34,6 +35,47 @@ pub extern "C" fn qibo_core_circuit_add(
 #[no_mangle]
 pub extern "C" fn qibo_core_circuit_n_elements(circuit: &Circuit) -> usize {
     circuit.n_elements()
+}
+
+#[no_mangle]
+pub extern "C" fn qibo_core_circuit_n_gates(circuit: &Circuit) -> usize {
+    circuit.n_gates()
+}
+
+#[no_mangle]
+pub extern "C" fn qibo_core_circuit_gate(circuit: &Circuit, gid: usize) -> *const c_char {
+    let gate = circuit.gate(gid);
+    let name = match gate {
+        Gate::One(One::H) => "H",
+        Gate::One(One::X) => "X",
+        Gate::One(One::Y) => "Y",
+        Gate::One(One::Z) => "Z",
+        Gate::Two(Two::CNOT) => "CNOT",
+        _ => todo!()
+    };
+
+    CString::new(name).unwrap().into_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn qibo_core_circuit_elements(circuit: &Circuit, gid: usize, ptr: *mut *const usize, len: *mut usize) {
+    let elements = circuit.elements(gid);
+    // Complaints about what follows are to be directed to ChatGPT
+    let boxed_slice = elements.clone().into_boxed_slice();
+    unsafe {
+        *ptr = boxed_slice.as_ptr();
+        *len = elements.len();
+    }
+    std::mem::forget(boxed_slice);
+}
+
+#[no_mangle]
+pub extern "C" fn qibo_core_circuit_free_elements(ptr: *const usize, len: usize) {
+    if !ptr.is_null() {
+        unsafe {
+            let _ = Vec::from_raw_parts(ptr as *mut usize, len, len);
+        }
+    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
Adds a micro-state vector-simulator written in C based on the qibojit functions. It can be used to simulate only single-qubit gates controlled on arbitrary number of qubits. This is sufficient to execute the circuit in the example.

Most likely it is possible to improve some things, in particular how the `elements` (gate targets) vector is moved from Rust to C and how gates are mapped to matrices. Maybe also the compilation process. For now I compiled with:
```sh
cc -c microsimulator/microsim.c -o microsim.o -I./prefix/include/qibo_core_c -L./prefix/lib/x86_64-linux-gnu -lqibo_core_c
cc -c examples/circuit.c -o circuit.o -I./microsimulator -I./prefix/include/qibo_core_c -L./prefix/lib/x86_64-linux-gnu -lqibo_core_c
cc microsim.o circuit.o -o circuit -I./microsimulator -I./prefix/include/qibo_core_c -L./prefix/lib/x86_64-linux-gnu -lqibo_core_c
```
ran inside the `crates/c` directory.

The example circuit can be executed and the result agrees with qibo-numpy simulation.